### PR TITLE
Added license data to dist.ini.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,2 +1,5 @@
+license = Perl_5
+copyright_holder = Wallace Reis
+copyright_year = 2013
 [@Milla]
 [MinimumPerlFast]


### PR DESCRIPTION
Hi, this is from [pullrequest.club](https://pullrequest.club).

If the user has no config file `~/.dzil/config.ini` with license data, `dzil build` aborts with error:

```
[DZ] no license data in config, no %Rights stash, couldn't make a good guess at license from Pod; giving up.  Perhaps you need to set up a global config file (dzil setup)?
```